### PR TITLE
Update functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -321,7 +321,8 @@ function mtl_posted_on2() {
 /**
  * make all users selectable for user dropdown in admin edit proposal page
  */
-add_filter('wp_dropdown_users', 'mtl_switch_user');
+/* DEACTIVATED BECAUSE OF FATAL PROBLEMS ON BULK EDITING OF POSTS!!! */
+/*add_filter('wp_dropdown_users', 'mtl_switch_user');
 function mtl_switch_user()
 {
     global $post; // remove if not needed
@@ -341,7 +342,7 @@ function mtl_switch_user()
     }
     echo'</select>';
 
-}
+}*/
 
 /**
  * add tinyMCE editor to comment form


### PR DESCRIPTION
Deactivated feature for selecting all users in post edit user dropdown because current solution unintendedly changes authors of posts on bulk edit!!! New solution required.

The author dropdown in WP editing posts view only allows to select admins and editors (afaik), but we need a possibility to select any author. This works with the solution that has been deactivated now, but only in the single post edit view. As there is no "empty author field" in the author dropdown in bulk editing dialogue, there's always an author selected instead of the default "no changes" setting for the author field, so this forces an author change of the edited posts, even when it was not intended.